### PR TITLE
Feat/telemetry: implement altittude-based styling; bbox visuals; backend testing

### DIFF
--- a/backend/src/common/integrations/opensky/OPENSKY_API.md
+++ b/backend/src/common/integrations/opensky/OPENSKY_API.md
@@ -44,36 +44,36 @@ Retrieves the trajectory (path) of a specific aircraft.
 OpenSky uses positional arrays (tuples) for performance. These are mapped in `types.ts`.
 
 ### 3.1 State Vector Tuple (`StateVectorTuple`)
-| Index | Field | Type | Description |
-| :--- | :--- | :--- | :--- |
-| 0 | `icao24` | `string` | Unique ICAO 24-bit address (hex). |
-| 1 | `callsign` | `string \| null` | 8-character callsign. |
-| 2 | `origin_country` | `string` | Country of origin. |
-| 3 | `time_position` | `number \| null` | Last position update (Unix seconds). |
-| 4 | `last_contact` | `number` | Last update in general (Unix seconds). |
-| 5 | `longitude` | `number \| null` | WGS-84 longitude (decimal degrees). |
-| 6 | `latitude` | `number \| null` | WGS-84 latitude (decimal degrees). |
-| 7 | `baro_altitude` | `number \| null` | Barometric altitude (meters). |
-| 8 | `on_ground` | `boolean` | True if aircraft is on ground. |
-| 9 | `velocity` | `number \| null` | Velocity over ground (m/s). |
-| 10 | `true_track` | `number \| null` | True track (decimal degrees, 0° = North). |
-| 11 | `vertical_rate` | `number \| null` | Vertical rate (m/s, positive = climb). |
-| 12 | `sensors` | `number[] \| null` | IDs of contributing receivers. |
-| 13 | `geo_altitude` | `number \| null` | Geometric altitude (meters). |
-| 14 | `squawk` | `string \| null` | Transponder code (Squawk). |
-| 15 | `spi` | `boolean` | Special Purpose Indicator flag. |
-| 16 | `position_source`| `number` | Source (0=ADS-B, 1=Asterix, 2=MLAT). |
-| 17 | `category` | `number` | Aircraft category (0-20). |
+| Index | Field             | Type               | Description                               |
+|:------|:------------------|:-------------------|:------------------------------------------|
+| 0     | `icao24`          | `string`           | Unique ICAO 24-bit address (hex).         |
+| 1     | `callsign`        | `string \| null`   | 8-character callsign.                     |
+| 2     | `origin_country`  | `string`           | Country of origin.                        |
+| 3     | `time_position`   | `number \| null`   | Last position update (Unix seconds).      |
+| 4     | `last_contact`    | `number`           | Last update in general (Unix seconds).    |
+| 5     | `longitude`       | `number \| null`   | WGS-84 longitude (decimal degrees).       |
+| 6     | `latitude`        | `number \| null`   | WGS-84 latitude (decimal degrees).        |
+| 7     | `baro_altitude`   | `number \| null`   | Barometric altitude (meters).             |
+| 8     | `on_ground`       | `boolean`          | True if aircraft is on ground.            |
+| 9     | `velocity`        | `number \| null`   | Velocity over ground (m/s).               |
+| 10    | `true_track`      | `number \| null`   | True track (decimal degrees, 0° = North). |
+| 11    | `vertical_rate`   | `number \| null`   | Vertical rate (m/s, positive = climb).    |
+| 12    | `sensors`         | `number[] \| null` | IDs of contributing receivers.            |
+| 13    | `geo_altitude`    | `number \| null`   | Geometric altitude (meters).              |
+| 14    | `squawk`          | `string \| null`   | Transponder code (Squawk).                |
+| 15    | `spi`             | `boolean`          | Special Purpose Indicator flag.           |
+| 16    | `position_source` | `number`           | Source (0=ADS-B, 1=Asterix, 2=MLAT).      |
+| 17    | `category`        | `number`           | Aircraft category (0-20).                 |
 
 ### 3.2 Track Path Tuple (`TrackPathTuple`)
-| Index | Field | Type | Description |
-| :--- | :--- | :--- | :--- |
-| 0 | `time` | `number` | Unix timestamp. |
-| 1 | `latitude` | `number \| null` | Latitude (decimal degrees). |
-| 2 | `longitude` | `number \| null` | Longitude (decimal degrees). |
-| 3 | `baro_altitude` | `number \| null` | Altitude (meters). |
-| 4 | `true_track` | `number \| null` | Heading (decimal degrees). |
-| 5 | `on_ground` | `boolean` | Ground status. |
+| Index | Field           | Type             | Description                  |
+|:------|:----------------|:-----------------|:-----------------------------|
+| 0     | `time`          | `number`         | Unix timestamp.              |
+| 1     | `latitude`      | `number \| null` | Latitude (decimal degrees).  |
+| 2     | `longitude`     | `number \| null` | Longitude (decimal degrees). |
+| 3     | `baro_altitude` | `number \| null` | Altitude (meters).           |
+| 4     | `true_track`    | `number \| null` | Heading (decimal degrees).   |
+| 5     | `on_ground`     | `boolean`        | Ground status.               |
 
 ---
 

--- a/backend/src/telemetry/__tests__/telemetry.dto.test.ts
+++ b/backend/src/telemetry/__tests__/telemetry.dto.test.ts
@@ -1,0 +1,106 @@
+import {
+  LocateFlightQuerySchema,
+  BoundingBoxAreaQuerySchema,
+} from "../telemetry.dto";
+
+describe("Telemetry DTO Schemas", () => {
+  describe("LocateFlightQuerySchema", () => {
+    it("should validate when faFlightId is provided", () => {
+      const result = LocateFlightQuerySchema.safeParse({
+        faFlightId: "AAL123-12345678",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should validate when icao24 is provided", () => {
+      const result = LocateFlightQuerySchema.safeParse({ icao24: "a1b2c3" });
+      expect(result.success).toBe(true);
+    });
+
+    it("should validate when both are provided", () => {
+      const result = LocateFlightQuerySchema.safeParse({
+        faFlightId: "AAL123-12345678",
+        icao24: "a1b2c3",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should fail when neither is provided", () => {
+      const result = LocateFlightQuerySchema.safeParse({});
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          "Należy podać faFlightId lub icao24.",
+        );
+      }
+    });
+  });
+
+  describe("BoundingBoxAreaQuerySchema", () => {
+    it("should validate a correct bounding box", () => {
+      const result = BoundingBoxAreaQuerySchema.safeParse({
+        lamin: 50,
+        lamax: 52,
+        lomin: 20,
+        lomax: 22,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should coerce strings to numbers", () => {
+      const result = BoundingBoxAreaQuerySchema.safeParse({
+        lamin: "50",
+        lamax: "52",
+        lomin: "20",
+        lomax: "22",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.lamin).toBe(50);
+      }
+    });
+
+    it("should fail if lamin >= lamax", () => {
+      const result = BoundingBoxAreaQuerySchema.safeParse({
+        lamin: 52,
+        lamax: 50,
+        lomin: 20,
+        lomax: 22,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          "Parametr 'lamin' musi być mniejszy niż 'lamax'",
+        );
+      }
+    });
+
+    it("should fail if lomin > lomax", () => {
+      const result = BoundingBoxAreaQuerySchema.safeParse({
+        lamin: 50,
+        lamax: 52,
+        lomin: 22,
+        lomax: 20,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          "Parametr 'lomin' musi być mniejszy niż 'lomax'",
+        );
+      }
+    });
+
+    it("should fail if coordinates are out of bounds", () => {
+      const result = BoundingBoxAreaQuerySchema.safeParse({
+        lamin: -91,
+        lamax: 91,
+        lomin: -181,
+        lomax: 181,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toHaveLength(4);
+      }
+    });
+  });
+});

--- a/backend/src/telemetry/__tests__/telemetry.repository.test.ts
+++ b/backend/src/telemetry/__tests__/telemetry.repository.test.ts
@@ -1,0 +1,85 @@
+import { TelemetryRepository } from "../telemetry.repository";
+import { DataSource, Repository } from "typeorm";
+import { FlightTelemetry } from "./../entities/FlightTelemetry";
+
+describe("TelemetryRepository", () => {
+  let repository: TelemetryRepository;
+  let mockDataSource: jest.Mocked<DataSource>;
+  let mockRepo: jest.Mocked<Repository<FlightTelemetry>>;
+
+  beforeEach(() => {
+    mockRepo = {
+      create: jest.fn(),
+      save: jest.fn(),
+    } as unknown as jest.Mocked<Repository<FlightTelemetry>>;
+
+    mockDataSource = {
+      getRepository: jest.fn().mockReturnValue(mockRepo),
+      query: jest.fn(),
+    } as unknown as jest.Mocked<DataSource>;
+
+    repository = new TelemetryRepository(mockDataSource);
+  });
+
+  describe("save", () => {
+    it("should create and save a telemetry entry", async () => {
+      const data = { icao24: "abc", flightId: "uuid" };
+      const entry = { ...data, id: "1" } as unknown as FlightTelemetry;
+      mockRepo.create.mockReturnValue(entry);
+      mockRepo.save.mockResolvedValue(entry);
+
+      const result = await repository.save(data);
+
+      expect(mockRepo.create).toHaveBeenCalledWith(data);
+      expect(mockRepo.save).toHaveBeenCalledWith(entry);
+      expect(result).toEqual(entry);
+    });
+  });
+
+  describe("calculateDistances", () => {
+    it("should return parsed distances from spatial query", async () => {
+      const mockResult = [
+        {
+          distanceFromOriginKm: "123.456",
+          distanceToDestinationKm: "789.012",
+        },
+      ];
+      mockDataSource.query.mockResolvedValue(mockResult);
+
+      const result = await repository.calculateDistances("telemetry-uuid");
+
+      expect(mockDataSource.query).toHaveBeenCalled();
+      expect(result).toEqual({
+        distanceFromOriginKm: 123.456,
+        distanceToDestinationKm: 789.012,
+      });
+    });
+
+    it("should return nulls if query returns no data", async () => {
+      mockDataSource.query.mockResolvedValue([]);
+
+      const result = await repository.calculateDistances("telemetry-uuid");
+
+      expect(result).toEqual({
+        distanceFromOriginKm: null,
+        distanceToDestinationKm: null,
+      });
+    });
+
+    it("should handle null values from database", async () => {
+      mockDataSource.query.mockResolvedValue([
+        {
+          distanceFromOriginKm: null,
+          distanceToDestinationKm: null,
+        },
+      ]);
+
+      const result = await repository.calculateDistances("telemetry-uuid");
+
+      expect(result).toEqual({
+        distanceFromOriginKm: null,
+        distanceToDestinationKm: null,
+      });
+    });
+  });
+});

--- a/backend/src/telemetry/__tests__/telemetry.service.test.ts
+++ b/backend/src/telemetry/__tests__/telemetry.service.test.ts
@@ -1,0 +1,339 @@
+import { TelemetryService } from "../telemetry.service";
+import {
+  getAeroApiClient,
+  AeroAPIClient,
+} from "../../common/integrations/aeroapi";
+import {
+  getOpenSkyClient,
+  OpenSkyClient,
+  StateVectorTuple,
+  OpenSkyStateVectorsResponse,
+} from "../../common/integrations/opensky";
+import { TelemetryRepository } from "../telemetry.repository";
+import { FlightsRepository } from "../../flights/flights.repository";
+import { FlightsService } from "../../flights/flights.service";
+import { TelemetryNotFoundError } from "../../common/errors";
+import { BoundingBoxLimitError } from "../telemetry.errors";
+import { DataSource } from "typeorm";
+import { Flight } from "../../flights/entities/Flight";
+import { FlightTelemetry } from "../entities/FlightTelemetry";
+import { FlightDetailsResponseDTO } from "../../flights/flights.dto";
+import {
+  AeroAPIFlightDetails,
+  AeroAPIStandardFlightsResponse,
+  AeroAPIFlightPositionResponse,
+  AeroAPILastPosition,
+} from "../../common/integrations/aeroapi/types";
+import {
+  createMockAeroFlightPosition,
+  createMockAeroFlightsResponse,
+  createMockAeroPosition,
+  createMockStateVector,
+} from "./test-utils";
+
+jest.mock("../../common/integrations/aeroapi");
+jest.mock("../../common/integrations/opensky");
+jest.mock("../telemetry.repository");
+jest.mock("../../flights/flights.repository");
+jest.mock("../../flights/flights.service");
+jest.mock("../../common/database/data-source");
+
+describe("TelemetryService", () => {
+  let service: TelemetryService;
+  let mockAeroClient: jest.Mocked<AeroAPIClient>;
+  let mockOpenSkyClient: jest.Mocked<OpenSkyClient>;
+  let mockTelemetryRepo: jest.Mocked<TelemetryRepository>;
+  let mockFlightsRepo: jest.Mocked<FlightsRepository>;
+  let mockFlightsService: jest.Mocked<FlightsService>;
+
+  beforeEach(() => {
+    mockAeroClient = {
+      getFlightPosition: jest.fn(),
+      getFlightInfo: jest.fn(),
+    } as unknown as jest.Mocked<AeroAPIClient>;
+
+    mockOpenSkyClient = {
+      getAllStateVectors: jest.fn(),
+    } as unknown as jest.Mocked<OpenSkyClient>;
+
+    (getAeroApiClient as jest.Mock).mockReturnValue(mockAeroClient);
+    (getOpenSkyClient as jest.Mock).mockReturnValue(mockOpenSkyClient);
+
+    service = new TelemetryService({} as unknown as DataSource);
+
+    const serviceInternal = service as unknown as Record<string, unknown>;
+    mockTelemetryRepo =
+      serviceInternal.telemetryRepository as jest.Mocked<TelemetryRepository>;
+    mockFlightsRepo =
+      serviceInternal.flightsRepository as jest.Mocked<FlightsRepository>;
+    mockFlightsService =
+      serviceInternal.flightsService as jest.Mocked<FlightsService>;
+  });
+
+  describe("getFlightsInArea", () => {
+    const query = { lamin: 50, lamax: 51, lomin: 20, lomax: 21 };
+
+    it("should return mapped flight states when data is available", async () => {
+      const mockStates: OpenSkyStateVectorsResponse = {
+        time: 12345678,
+        states: [
+          createMockStateVector({
+            icao24: "icao1",
+            callsign: "CALL1   ",
+            lat: 50.5,
+            lon: 20.5,
+          }),
+        ],
+      };
+      mockOpenSkyClient.getAllStateVectors.mockResolvedValue(mockStates);
+
+      const result = await service.getFlightsInArea(query);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        icao24: "icao1",
+        callsign: "CALL1",
+        location: {
+          type: "Point",
+          coordinates: [20.5, 50.5],
+        },
+        altitude: 10000,
+        velocity: 200,
+        heading: 90,
+        onGround: false,
+      });
+    });
+
+    it("should filter out states with missing coordinates", async () => {
+      const mockStates: OpenSkyStateVectorsResponse = {
+        time: 12345678,
+        states: [
+          createMockStateVector({ icao24: "icao1", lon: null, lat: 50.5 }),
+          createMockStateVector({ icao24: "icao2", lon: 20.5, lat: null }),
+          createMockStateVector({ icao24: "icao3", lon: 20.5, lat: 50.5 }),
+        ],
+      };
+      mockOpenSkyClient.getAllStateVectors.mockResolvedValue(mockStates);
+
+      const result = await service.getFlightsInArea(query);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].icao24).toBe("icao3");
+    });
+
+    it("should return empty array if no states found", async () => {
+      mockOpenSkyClient.getAllStateVectors.mockResolvedValue({
+        time: 0,
+        states: null,
+      });
+
+      const result = await service.getFlightsInArea(query);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should throw BoundingBoxLimitError if area exceeds limit", async () => {
+      const largeQuery = { lamin: 0, lamax: 30, lomin: 0, lomax: 20 };
+      await expect(service.getFlightsInArea(largeQuery)).rejects.toThrow(
+        BoundingBoxLimitError,
+      );
+    });
+  });
+
+  describe("locateAndSaveFlight", () => {
+    it("should resolve by ICAO24 direct lookup when possible", async () => {
+      const query = { icao24: "icao1" };
+      const mockState = createMockStateVector({
+        icao24: "icao1",
+        callsign: "CALL1",
+        lon: 20,
+        lat: 50,
+      });
+      mockOpenSkyClient.getAllStateVectors.mockResolvedValue({
+        time: 123456,
+        states: [mockState],
+      });
+      mockFlightsService.getFlightDetailsAndSave.mockResolvedValue({
+        faFlightId: "fa1",
+      } as unknown as FlightDetailsResponseDTO);
+      mockFlightsRepo.findByFaFlightId.mockResolvedValue({
+        id: "flight-uuid",
+      } as unknown as Flight);
+      mockTelemetryRepo.save.mockResolvedValue({
+        id: "telemetry-id",
+        icao24: "icao1",
+        flightId: "flight-uuid",
+        timestamp: new Date("2026-05-05"),
+        location: { type: "Point", coordinates: [20, 50] },
+      } as unknown as FlightTelemetry);
+      mockTelemetryRepo.calculateDistances.mockResolvedValue({
+        distanceFromOriginKm: 100,
+        distanceToDestinationKm: 200,
+      });
+
+      const result = await service.locateAndSaveFlight(query);
+
+      expect(result.faFlightId).toBe("fa1");
+      expect(result.distanceFromOriginKm).toBe(100);
+      expect(mockOpenSkyClient.getAllStateVectors).toHaveBeenCalledWith(
+        undefined,
+        "icao1",
+      );
+    });
+
+    it("should fallback to Strategy 2 (spatial match) if faFlightId is provided and icao24 lookup fails", async () => {
+      const query = { faFlightId: "fa1" };
+
+      // AeroAPI Position
+      mockAeroClient.getFlightPosition.mockResolvedValue(
+        createMockAeroFlightPosition({
+          ident_icao: "CALL2",
+          last_position: createMockAeroPosition({
+            latitude: 52.0,
+            longitude: 21.0,
+          }),
+        }),
+      );
+      // AeroAPI Info for atc_ident
+      mockAeroClient.getFlightInfo.mockResolvedValue(
+        createMockAeroFlightsResponse([{ atc_ident: "CALL2" }]),
+      );
+
+      // OpenSky returns a match near that position
+      const mockMatch = createMockStateVector({
+        icao24: "icao2",
+        callsign: "CALL2",
+        lon: 21.1,
+        lat: 52.1,
+        alt: 5000,
+        velocity: 150,
+        heading: 45,
+      });
+      mockOpenSkyClient.getAllStateVectors.mockResolvedValue({
+        time: 123456,
+        states: [mockMatch],
+      });
+
+      // Repositories
+      mockFlightsRepo.findByFaFlightId.mockResolvedValue({
+        id: "f-uuid",
+      } as Flight);
+      mockTelemetryRepo.save.mockResolvedValue({
+        id: "t-id",
+        icao24: "icao2",
+        flightId: "f-uuid",
+        timestamp: new Date(),
+        location: { type: "Point", coordinates: [21.1, 52.1] },
+      } as FlightTelemetry);
+      mockTelemetryRepo.calculateDistances.mockResolvedValue({
+        distanceFromOriginKm: 50,
+        distanceToDestinationKm: 50,
+      });
+
+      const result = await service.locateAndSaveFlight(query);
+
+      expect(result.icao24).toBe("icao2");
+      expect(mockAeroClient.getFlightPosition).toHaveBeenCalledWith("fa1");
+      // Check if bounding box was created around 52, 21
+      expect(mockOpenSkyClient.getAllStateVectors).toHaveBeenCalledWith(
+        expect.objectContaining({ lamin: 50.5, lamax: 53.5 }),
+      );
+    });
+
+    it("should throw BoundingBoxLimitError if state vector coordinates are null during persistence", async () => {
+      const query = { icao24: "icao1" };
+      const mockState = createMockStateVector({
+        icao24: "icao1",
+        callsign: "CALL1",
+        lon: null,
+        lat: null,
+      });
+      mockOpenSkyClient.getAllStateVectors.mockResolvedValue({
+        time: 123456,
+        states: [mockState],
+      });
+      mockFlightsService.getFlightDetailsAndSave.mockResolvedValue({
+        faFlightId: "fa1",
+      } as unknown as FlightDetailsResponseDTO);
+      mockFlightsRepo.findByFaFlightId.mockResolvedValue({
+        id: "f-uuid",
+      } as Flight);
+
+      await expect(service.locateAndSaveFlight(query)).rejects.toThrow(
+        BoundingBoxLimitError,
+      );
+    });
+
+    it("should throw TelemetryNotFoundError if AeroAPI returns no spatial data for faFlightId", async () => {
+      const query = { faFlightId: "fa-no-pos" };
+      mockAeroClient.getFlightPosition.mockResolvedValue(
+        createMockAeroFlightPosition({ last_position: null }),
+      );
+
+      await expect(service.locateAndSaveFlight(query)).rejects.toThrow(
+        "No active spatial data (last_position) for fa-no-pos.",
+      );
+    });
+
+    it("should throw TelemetryNotFoundError if no callsign matches in spatial search", async () => {
+      const query = { faFlightId: "fa1" };
+      mockAeroClient.getFlightPosition.mockResolvedValue(
+        createMockAeroFlightPosition({
+          ident_icao: "CALL-X",
+          last_position: createMockAeroPosition({
+            latitude: 52,
+            longitude: 21,
+          }),
+        }),
+      );
+      mockAeroClient.getFlightInfo.mockResolvedValue(
+        createMockAeroFlightsResponse([{ atc_ident: null }]),
+      );
+      mockOpenSkyClient.getAllStateVectors.mockResolvedValue({
+        time: 123456,
+        states: [
+          createMockStateVector({
+            icao24: "icao-other",
+            callsign: "OTHER",
+            lon: 21,
+            lat: 52,
+          }),
+        ],
+      });
+
+      await expect(service.locateAndSaveFlight(query)).rejects.toThrow(
+        "Could not match callsign CALL-X to any OpenSky state vector near its last known position.",
+      );
+    });
+
+    it("should throw TelemetryNotFoundError if no state vector found", async () => {
+      const query = { icao24: "icao1" };
+      mockOpenSkyClient.getAllStateVectors.mockResolvedValue({
+        time: 0,
+        states: [],
+      });
+
+      await expect(service.locateAndSaveFlight(query)).rejects.toThrow(
+        TelemetryNotFoundError,
+      );
+    });
+
+    it("should throw TelemetryNotFoundError if callsign missing for ICAO lookup", async () => {
+      const query = { icao24: "icao1" };
+      const mockState = createMockStateVector({
+        icao24: "icao1",
+        callsign: null,
+        lon: 20,
+        lat: 50,
+      });
+      mockOpenSkyClient.getAllStateVectors.mockResolvedValue({
+        time: 0,
+        states: [mockState],
+      });
+
+      await expect(service.locateAndSaveFlight(query)).rejects.toThrow(
+        "Could not resolve callsign for aircraft icao1 from OpenSky.",
+      );
+    });
+  });
+});

--- a/backend/src/telemetry/__tests__/telemetry.utils.test.ts
+++ b/backend/src/telemetry/__tests__/telemetry.utils.test.ts
@@ -1,0 +1,90 @@
+import { TelemetryUtils } from "../telemetry.utils";
+import { BoundingBoxLimitError } from "../telemetry.errors";
+
+describe("TelemetryUtils", () => {
+  describe("createBoundingBox", () => {
+    it("should create a bounding box with the default buffer", () => {
+      const lat = 52.0;
+      const lon = 21.0;
+      const buffer = TelemetryUtils.SPATIAL_BUFFER_DEGREES;
+
+      const result = TelemetryUtils.createBoundingBox(lat, lon);
+
+      expect(result).toEqual({
+        lamin: lat - buffer,
+        lamax: lat + buffer,
+        lomin: lon - buffer,
+        lomax: lon + buffer,
+      });
+    });
+
+    it("should clamp latitude to -90", () => {
+      const result = TelemetryUtils.createBoundingBox(-89.5, 0);
+      expect(result.lamin).toBe(-90);
+    });
+
+    it("should clamp latitude to 90", () => {
+      const result = TelemetryUtils.createBoundingBox(89.5, 0);
+      expect(result.lamax).toBe(90);
+    });
+
+    it("should clamp longitude to -180", () => {
+      const result = TelemetryUtils.createBoundingBox(0, -179.5);
+      expect(result.lomin).toBe(-180);
+    });
+
+    it("should clamp longitude to 180", () => {
+      const result = TelemetryUtils.createBoundingBox(0, 179.5);
+      expect(result.lomax).toBe(180);
+    });
+  });
+
+  describe("validateAreaLimits", () => {
+    it("should not throw error if area is within limit", () => {
+      const query = {
+        lamin: 50,
+        lamax: 60, // 10 degrees lat
+        lomin: 20,
+        lomax: 30, // 10 degrees lon
+      }; // Area = 100
+
+      expect(() => TelemetryUtils.validateAreaLimits(query)).not.toThrow();
+    });
+
+    it("should not throw error if area is exactly 400", () => {
+      const query = {
+        lamin: 0,
+        lamax: 20,
+        lomin: 0,
+        lomax: 20,
+      }; // Area = 400
+      expect(() => TelemetryUtils.validateAreaLimits(query)).not.toThrow();
+    });
+
+    it("should throw BoundingBoxLimitError if area exceeds limit", () => {
+      const query = {
+        lamin: 40,
+        lamax: 61, // 21 degrees lat
+        lomin: 10,
+        lomax: 30, // 20 degrees lon
+      }; // Area = 420 > 400
+
+      expect(() => TelemetryUtils.validateAreaLimits(query)).toThrow(
+        BoundingBoxLimitError,
+      );
+    });
+
+    it("should throw BoundingBoxLimitError with correct message", () => {
+      const query = {
+        lamin: 0,
+        lamax: 21,
+        lomin: 0,
+        lomax: 20,
+      }; // Area = 420
+
+      expect(() => TelemetryUtils.validateAreaLimits(query)).toThrow(
+        "Requested map area (420.00) sq° exceeded allowed limit 400 sq°",
+      );
+    });
+  });
+});

--- a/backend/src/telemetry/__tests__/test-utils.ts
+++ b/backend/src/telemetry/__tests__/test-utils.ts
@@ -1,0 +1,88 @@
+import { StateVectorTuple } from "../../common/integrations/opensky";
+import {
+  AeroAPIFlightDetails,
+  AeroAPIFlightPositionResponse,
+  AeroAPILastPosition,
+  AeroAPIStandardFlightsResponse,
+} from "../../common/integrations/aeroapi/types";
+
+/**
+ * Creates a mock OpenSky StateVectorTuple with sensible defaults.
+ */
+export const createMockStateVector = (
+  overrides: Partial<{
+    icao24: string;
+    callsign: string | null;
+    lon: number | null;
+    lat: number | null;
+    alt: number | null;
+    velocity: number | null;
+    heading: number | null;
+    onGround: boolean;
+  }> = {},
+): StateVectorTuple => {
+  return [
+    overrides.icao24 !== undefined ? overrides.icao24 : "icao123",
+    overrides.callsign !== undefined ? overrides.callsign : "CALL123 ",
+    "origin",
+    0,
+    0,
+    overrides.lon !== undefined ? overrides.lon : 21.0,
+    overrides.lat !== undefined ? overrides.lat : 52.0,
+    overrides.alt !== undefined ? overrides.alt : 10000,
+    overrides.onGround ?? false,
+    overrides.velocity !== undefined ? overrides.velocity : 200,
+    overrides.heading !== undefined ? overrides.heading : 90,
+    0,
+    null,
+    null,
+    null,
+    false,
+    0,
+    0,
+  ];
+};
+
+/**
+ * Creates a mock AeroAPI Last Position object.
+ */
+export const createMockAeroPosition = (
+  overrides: Partial<AeroAPILastPosition> = {},
+): AeroAPILastPosition => {
+  return {
+    fa_flight_id: "fa123",
+    altitude: 30000,
+    latitude: 52.0,
+    longitude: 21.0,
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  } as AeroAPILastPosition;
+};
+
+/**
+ * Creates a mock AeroAPI Flight Position response.
+ */
+export const createMockAeroFlightPosition = (
+  overrides: Partial<AeroAPIFlightPositionResponse> = {},
+): AeroAPIFlightPositionResponse => {
+  return {
+    ident: "AAL123",
+    ident_icao: "AAL123",
+    ident_iata: "AA123",
+    atc_ident: "AAL123",
+    fa_flight_id: "fa123",
+    last_position: createMockAeroPosition(),
+    ...overrides,
+  } as AeroAPIFlightPositionResponse;
+};
+
+/**
+ * Creates a mock AeroAPI Standard Flights response.
+ */
+export const createMockAeroFlightsResponse = (
+  flights: Partial<AeroAPIFlightDetails>[] = [],
+): AeroAPIStandardFlightsResponse => {
+  return {
+    flights: flights.map((f) => ({ ...f }) as AeroAPIFlightDetails),
+  } as AeroAPIStandardFlightsResponse;
+};

--- a/backend/src/telemetry/entities/FlightTelemetry.ts
+++ b/backend/src/telemetry/entities/FlightTelemetry.ts
@@ -11,12 +11,18 @@ import { Flight } from "../../flights/entities/Flight";
 import { HexIcao24AddressTransformer } from "../../common/utils/HexTransformer";
 import { BaseEntity } from "../../common/database/BaseEntity";
 
+/**
+ * Entity representing a single telemetry data point for a flight.
+ * Stores spatial location, altitude, velocity, and orientation at a specific point in time.
+ */
 @Entity("flight_telemetry")
 @Index(["flightId", "timestamp"])
 export class FlightTelemetry extends BaseEntity {
+  /** Unique identifier for the telemetry entry. */
   @PrimaryGeneratedColumn("increment", { type: "bigint" })
   id!: string;
 
+  /** 24-bit ICAO aircraft address in hex format. */
   @Column({
     type: "integer",
     name: "icao24",
@@ -24,16 +30,20 @@ export class FlightTelemetry extends BaseEntity {
   })
   icao24!: string;
 
+  /** Internal UUID reference to the associated Flight entity. */
   @Column({ type: "uuid", name: "flight_id" })
   flightId!: string;
 
+  /** Reference to the Flight entity. */
   @ManyToOne(() => Flight, (flight) => flight.telemetry)
   @JoinColumn({ name: "flight_id" })
   flight!: Flight;
 
+  /** Point in time when the telemetry was recorded. */
   @Column({ type: "timestamptz", nullable: false })
   timestamp!: Date;
 
+  /** Geospatial location (Point) in WGS84 (SRID 4326). */
   @Index({ spatial: true })
   @Column({
     type: "geometry",
@@ -43,15 +53,19 @@ export class FlightTelemetry extends BaseEntity {
   })
   location!: Point;
 
+  /** Barometric altitude in feet. */
   @Column({ type: "int", nullable: true })
   altitude!: number | null;
 
+  /** Ground speed in knots. */
   @Column({ type: "decimal", precision: 7, scale: 2, nullable: true })
   velocity!: number | null;
 
+  /** Magnetic heading in degrees (0-359). */
   @Column({ type: "decimal", precision: 5, scale: 2, nullable: true })
   heading!: number | null;
 
+  /** Indicates if the aircraft was on the ground at the time of recording. */
   @Column({ type: "boolean", nullable: false, name: "on_ground" })
   onGround!: boolean;
 }

--- a/backend/src/telemetry/telemetry.dto.ts
+++ b/backend/src/telemetry/telemetry.dto.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { Point } from "geojson";
 
+/**
+ * Schema for locating a flight using ICAO24 or AeroAPI flight ID.
+ * Requires at least one of the identifiers to be present.
+ */
 export const LocateFlightQuerySchema = z
   .object({
     faFlightId: z.string().optional(),
@@ -16,18 +20,34 @@ export const LocateFlightQuerySchema = z
     }
   });
 
+/**
+ * Type inferred from LocateFlightQuerySchema.
+ */
 export type LocateFlightQuery = z.infer<typeof LocateFlightQuerySchema>;
 
+/**
+ * Data Transfer Object for flight location response.
+ */
 export interface LocateFlightResponseDTO {
+  /** 24-bit ICAO aircraft address in hex. */
   icao24: string;
+  /** AeroAPI unique flight identifier. */
   faFlightId: string;
+  /** Internal system UUID for the flight. */
   internalFlightId: string; // UUID reference to main domain
+  /** Current geospatial location. */
   location: Point;
+  /** Distance from origin airport in kilometers. */
   distanceFromOriginKm?: number | null;
+  /** Distance to destination airport in kilometers. */
   distanceToDestinationKm?: number | null;
+  /** ISO timestamp when this state was persisted. */
   persistedAt: string;
 }
 
+/**
+ * Schema for querying flights within a specific geographic bounding box.
+ */
 export const BoundingBoxAreaQuerySchema = z
   .object({
     lamin: z.coerce.number().min(-90).max(90),
@@ -53,14 +73,27 @@ export const BoundingBoxAreaQuerySchema = z
     }
   });
 
+/**
+ * Type inferred from BoundingBoxAreaQuerySchema.
+ */
 export type BoundingBoxAreaQuery = z.infer<typeof BoundingBoxAreaQuerySchema>;
 
+/**
+ * Summary DTO for displaying a flight on the map.
+ */
 export interface MapFlightSummaryDTO {
+  /** 24-bit ICAO aircraft address in hex. */
   icao24: string;
+  /** Aircraft call sign (ATC). */
   callsign: string | null;
+  /** Current geospatial location. */
   location: Point;
+  /** Barometric altitude in meters. */
   altitude: number | null;
+  /** Ground speed in meters per second. */
   velocity: number | null;
+  /** Magnetic heading in degrees. */
   heading: number | null;
+  /** Indicates if the aircraft is on the ground. */
   onGround: boolean;
 }

--- a/backend/src/telemetry/telemetry.errors.ts
+++ b/backend/src/telemetry/telemetry.errors.ts
@@ -1,3 +1,7 @@
+/**
+ * Error thrown when a requested bounding box area exceeds the system's security limits.
+ * Typically results in a 400 Bad Request response.
+ */
 export class BoundingBoxLimitError extends Error {
   public readonly statusCode: number = 400;
 
@@ -13,6 +17,10 @@ export class BoundingBoxLimitError extends Error {
   }
 }
 
+/**
+ * Error thrown when an external API rate limit is reached.
+ * Typically results in a 429 Too Many Requests response.
+ */
 export class RateLimitExceededError extends Error {
   public readonly statusCode: number = 429;
 
@@ -24,6 +32,10 @@ export class RateLimitExceededError extends Error {
   }
 }
 
+/**
+ * Error thrown when received telemetry data is considered too old to be useful.
+ * Typically results in a 409 Conflict response.
+ */
 export class DataStaleError extends Error {
   public readonly statusCode: number = 409;
 

--- a/backend/src/telemetry/telemetry.repository.ts
+++ b/backend/src/telemetry/telemetry.repository.ts
@@ -2,8 +2,13 @@ import { DataSource, Repository, EntityManager } from "typeorm";
 import { AppDataSource } from "../common/database/data-source";
 import { FlightTelemetry } from "./entities/FlightTelemetry";
 
+/**
+ * Container for calculated spatial distances.
+ */
 export interface TelemetryDistances {
+  /** Distance from the origin airport in kilometers. */
   distanceFromOriginKm: number | null;
+  /** Distance to the destination airport in kilometers. */
   distanceToDestinationKm: number | null;
 }
 

--- a/backend/src/telemetry/telemetry.routes.ts
+++ b/backend/src/telemetry/telemetry.routes.ts
@@ -13,8 +13,11 @@ const router = Router();
 const telemetryService = new TelemetryService();
 
 /**
- * Hermetyzuje asynchroniczne funkcje obłusgi żądań, automatycznie przekazując
- * nieprzechwycone wyjątki go globalnego middleware
+ * Hermetyzuje asynchroniczne funkcje obsługi żądań, automatycznie przekazując
+ * nieprzechwycone wyjątki do globalnego middleware.
+ *
+ * @param fn - Asynchroniczna funkcja obsługi żądania Express.
+ * @returns Funkcja middleware Express obsługująca błędy.
  */
 function asyncHandler(
   fn: (req: Request, res: Response, next: NextFunction) => Promise<void>,
@@ -49,7 +52,10 @@ router.get(
 );
 
 /**
- *
+ * Endpoint GET /telemetry/area
+ * Pobiera listę wszystkich aktywnych lotów w danym obszarze geograficznym (Bounding Box).
+ * Wykorzystuje OpenSky Network API do pobierania wektorów stanu.
+ * Obszar jest ograniczony do 400 stopni kwadratowych ze względów wydajnościowych.
  */
 router.get(
   "/area",

--- a/backend/src/telemetry/telemetry.service.ts
+++ b/backend/src/telemetry/telemetry.service.ts
@@ -133,6 +133,11 @@ export class TelemetryService {
 
   /**
    * Resolves flight state and AeroAPI ID using a direct ICAO24 lookup.
+   *
+   * @param icao24 - 24-bit ICAO aircraft address in hex.
+   * @param existingFaFlightId - Optional pre-existing AeroAPI flight identifier.
+   * @returns Object containing the OpenSky state vector and the resolved AeroAPI flight ID.
+   * @throws {TelemetryNotFoundError} If no state vector is found or AeroAPI ID cannot be resolved.
    */
   private async resolveByIcao24(
     icao24: string,
@@ -183,6 +188,12 @@ export class TelemetryService {
 
   /**
    * Resolves flight state by matching AeroAPI's last known position to OpenSky state vectors in a spatial buffer.
+   * This is Strategy 2, used when ICAO24 lookup is not the primary entry point or fails.
+   *
+   * @param faFlightId - AeroAPI unique flight identifier.
+   * @param atcIdent - Optional ATC callsign for precise matching.
+   * @returns The matched OpenSky state vector.
+   * @throws {TelemetryNotFoundError} If spatial data is missing or no matching callsign is found in the buffer.
    */
   private async resolveBySpatialMatch(
     faFlightId: string,
@@ -242,6 +253,12 @@ export class TelemetryService {
 
   /**
    * Persists a state vector as a telemetry entry and calculates related spatial metrics.
+   *
+   * @param state - The OpenSky state vector tuple.
+   * @param faFlightId - The associated AeroAPI flight identifier.
+   * @returns Enriched response DTO containing persistence details and distance metrics.
+   * @throws {FlightNotFoundError} If the flight record does not exist in the database.
+   * @throws {BoundingBoxLimitError} If the state vector lacks valid geographic coordinates.
    */
   private async persistTelemetry(
     state: StateVectorTuple,

--- a/backend/src/telemetry/telemetry.utils.ts
+++ b/backend/src/telemetry/telemetry.utils.ts
@@ -8,21 +8,24 @@ import { BoundingBoxLimitError } from "./telemetry.errors";
  */
 export const TelemetryUtils = {
   /**
-   * Area limit (in square degrees) to secure API credit usage.
+   * Area limit in square degrees to secure API credit usage.
+   * A value of 400 corresponds to a 20x20 degree box.
    */
   MAX_AREA_SQ_DEGREES: 400,
 
   /**
    * Spatial buffer in degrees for matching AeroAPI position to OpenSky states.
+   * Creates a 3x3 degree search area centered on the aircraft.
    */
   SPATIAL_BUFFER_DEGREES: 1.5,
 
   /**
    * Creates a BoundingBox around a given coordinate point using the spatial buffer.
+   * Clamps results to valid geographic coordinate ranges.
    *
-   * @param lat - Latitude
-   * @param lon - Longitude
-   * @returns OpenSky compatible BoundingBox
+   * @param lat - Center latitude.
+   * @param lon - Center longitude.
+   * @returns OpenSky compatible BoundingBox object.
    */
   createBoundingBox(lat: number, lon: number): BoundingBox {
     return {
@@ -35,9 +38,10 @@ export const TelemetryUtils = {
 
   /**
    * Validates that the requested bounding box area does not exceed security limits.
+   * Calculated as (max_lat - min_lat) * (max_lon - min_lon).
    *
-   * @param query - Bounding box area coordinates.
-   * @throws {BoundingBoxLimitError} If area exceeds limits.
+   * @param query - Bounding box area coordinates from the request.
+   * @throws {BoundingBoxLimitError} If the area exceeds MAX_AREA_SQ_DEGREES.
    */
   validateAreaLimits(query: BoundingBoxAreaQuery): void {
     const latRange = query.lamax - query.lamin;

--- a/frontend/app/telemetry/_components/AltitudeLegend.tsx
+++ b/frontend/app/telemetry/_components/AltitudeLegend.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Legend component showing the altitude-to-color gradient for airplane markers.
+ * Positioned horizontally at the bottom of the map.
+ */
+export function AltitudeLegend() {
+  return (
+    <div className="absolute left-1/2 -translate-x-1/2 bottom-8 z-10 flex flex-col items-center gap-1 py-1.5 px-16 bg-surface border-2 border-ink shadow-brut min-w-[800px]">
+      <p className="font-mono text-[10px] font-bold uppercase tracking-widest text-ink-muted leading-none">
+        Wysokość (metry)
+      </p>
+
+      <div className="w-full flex flex-col gap-1.5">
+        {/* Gradient Bar with Ticks */}
+        <div className="w-full relative h-3">
+          <div 
+            className="w-full h-full border border-ink/20"
+            style={{
+              background: "linear-gradient(to right, var(--lime), var(--navy))"
+            }}
+          />
+          {/* Tick Marks */}
+          {[0, 25, 50, 75, 100].map((pos) => (
+            <div 
+              key={pos} 
+              className="absolute top-0 h-full w-[2px] bg-ink/40 -translate-x-1/2" 
+              style={{ left: `${pos}%` }} 
+            />
+          ))}
+        </div>
+
+        {/* Labels positioned relative to the bar's width */}
+        <div className="w-full relative h-4">
+            <span className="absolute left-0 -translate-x-1/2 font-mono text-[10px] font-bold text-ink whitespace-nowrap">
+              0 m
+            </span>
+            <span className="absolute left-1/4 -translate-x-1/2 font-mono text-[10px] font-bold text-ink-muted whitespace-nowrap">
+              3,000 m
+            </span>
+            <span className="absolute left-1/2 -translate-x-1/2 font-mono text-[10px] font-bold text-ink-muted whitespace-nowrap">
+              6,000 m
+            </span>
+            <span className="absolute left-3/4 -translate-x-1/2 font-mono text-[10px] font-bold text-ink-muted whitespace-nowrap">
+              9,000 m
+            </span>
+            <span className="absolute left-full -translate-x-1/2 font-mono text-[10px] font-bold text-ink whitespace-nowrap">
+              12,000+ m
+            </span>
+        </div>
+      </div>
+    </div>
+
+  );
+}
+

--- a/frontend/app/telemetry/_components/AltitudeLegend.tsx
+++ b/frontend/app/telemetry/_components/AltitudeLegend.tsx
@@ -16,43 +16,41 @@ export function AltitudeLegend() {
       <div className="w-full flex flex-col gap-1.5">
         {/* Gradient Bar with Ticks */}
         <div className="w-full relative h-3">
-          <div 
+          <div
             className="w-full h-full border border-ink/20"
             style={{
-              background: "linear-gradient(to right, var(--lime), var(--navy))"
+              background: "linear-gradient(to right, var(--lime), var(--navy))",
             }}
           />
           {/* Tick Marks */}
           {[0, 25, 50, 75, 100].map((pos) => (
-            <div 
-              key={pos} 
-              className="absolute top-0 h-full w-[2px] bg-ink/40 -translate-x-1/2" 
-              style={{ left: `${pos}%` }} 
+            <div
+              key={pos}
+              className="absolute top-0 h-full w-[2px] bg-ink/40 -translate-x-1/2"
+              style={{ left: `${pos}%` }}
             />
           ))}
         </div>
 
         {/* Labels positioned relative to the bar's width */}
         <div className="w-full relative h-4">
-            <span className="absolute left-0 -translate-x-1/2 font-mono text-[10px] font-bold text-ink whitespace-nowrap">
-              0 m
-            </span>
-            <span className="absolute left-1/4 -translate-x-1/2 font-mono text-[10px] font-bold text-ink-muted whitespace-nowrap">
-              3,000 m
-            </span>
-            <span className="absolute left-1/2 -translate-x-1/2 font-mono text-[10px] font-bold text-ink-muted whitespace-nowrap">
-              6,000 m
-            </span>
-            <span className="absolute left-3/4 -translate-x-1/2 font-mono text-[10px] font-bold text-ink-muted whitespace-nowrap">
-              9,000 m
-            </span>
-            <span className="absolute left-full -translate-x-1/2 font-mono text-[10px] font-bold text-ink whitespace-nowrap">
-              12,000+ m
-            </span>
+          <span className="absolute left-0 -translate-x-1/2 font-mono text-[10px] font-bold text-ink whitespace-nowrap">
+            0 m
+          </span>
+          <span className="absolute left-1/4 -translate-x-1/2 font-mono text-[10px] font-bold text-ink-muted whitespace-nowrap">
+            3,000 m
+          </span>
+          <span className="absolute left-1/2 -translate-x-1/2 font-mono text-[10px] font-bold text-ink-muted whitespace-nowrap">
+            6,000 m
+          </span>
+          <span className="absolute left-3/4 -translate-x-1/2 font-mono text-[10px] font-bold text-ink-muted whitespace-nowrap">
+            9,000 m
+          </span>
+          <span className="absolute left-full -translate-x-1/2 font-mono text-[10px] font-bold text-ink whitespace-nowrap">
+            12,000+ m
+          </span>
         </div>
       </div>
     </div>
-
   );
 }
-

--- a/frontend/app/telemetry/_components/MapLayers.tsx
+++ b/frontend/app/telemetry/_components/MapLayers.tsx
@@ -2,7 +2,7 @@
 
 import { Source, Layer } from "react-map-gl/maplibre";
 import { EMPTY_GEOJSON } from "@/app/telemetry/_utils/telemetryMapHelpers";
-import {useThemeColors} from "@/common/hooks/UseThemeColors";
+import { useThemeColors } from "@/common/hooks/UseThemeColors";
 
 interface MapLayersProps {
   routesGeoJson: GeoJSON.FeatureCollection;
@@ -25,8 +25,7 @@ export function MapLayers({
   remainingPathGeoJson = EMPTY_GEOJSON,
   activeBBoxGeoJson = EMPTY_GEOJSON,
 }: MapLayersProps) {
-
-    const {navy, lime, ink, navyHover} = useThemeColors();
+  const { navy, lime, ink, navyHover } = useThemeColors();
 
   return (
     <>
@@ -137,9 +136,12 @@ export function MapLayers({
             "icon-size": [
               "interpolate",
               ["linear"],
-              ["ln", ["+", ["max", ["coalesce", ["get", "altitude"], 0], 0], 1]],
+              [
+                "ln",
+                ["+", ["max", ["coalesce", ["get", "altitude"], 0], 0], 1],
+              ],
               0,
-              0.50,
+              0.5,
               9.3927, // ln(12000 + 1)
               0.62,
             ],
@@ -158,9 +160,7 @@ export function MapLayers({
             "icon-halo-width": 2,
             "icon-halo-blur": 0,
           }}
-
         />
-
       </Source>
 
       {/* Animated airplanes along routes */}

--- a/frontend/app/telemetry/_components/MapLayers.tsx
+++ b/frontend/app/telemetry/_components/MapLayers.tsx
@@ -26,7 +26,7 @@ export function MapLayers({
   activeBBoxGeoJson = EMPTY_GEOJSON,
 }: MapLayersProps) {
 
-    const {navy, lime} = useThemeColors();
+    const {navy, lime, ink, navyHover} = useThemeColors();
 
   return (
     <>
@@ -130,13 +130,37 @@ export function MapLayers({
           id="flights-points"
           type="symbol"
           layout={{
-            "icon-image": "airplane-icon",
+            "icon-image": "airplane-icon-sdf",
             "icon-rotate": ["get", "heading"],
             "icon-rotation-alignment": "map",
             "icon-allow-overlap": true,
-            "icon-size": 0.5,
+            "icon-size": [
+              "interpolate",
+              ["linear"],
+              ["ln", ["+", ["max", ["coalesce", ["get", "altitude"], 0], 0], 1]],
+              0,
+              0.50,
+              9.3927, // ln(12000 + 1)
+              0.62,
+            ],
           }}
+          paint={{
+            "icon-color": [
+              "interpolate",
+              ["linear"],
+              ["max", ["coalesce", ["get", "altitude"], 0], 0],
+              0,
+              lime,
+              12000,
+              navy,
+            ],
+            "icon-halo-color": ink,
+            "icon-halo-width": 2,
+            "icon-halo-blur": 0,
+          }}
+
         />
+
       </Source>
 
       {/* Animated airplanes along routes */}

--- a/frontend/app/telemetry/_components/MapLayers.tsx
+++ b/frontend/app/telemetry/_components/MapLayers.tsx
@@ -2,6 +2,7 @@
 
 import { Source, Layer } from "react-map-gl/maplibre";
 import { EMPTY_GEOJSON } from "@/app/telemetry/_utils/telemetryMapHelpers";
+import {useThemeColors} from "@/common/hooks/UseThemeColors";
 
 interface MapLayersProps {
   routesGeoJson: GeoJSON.FeatureCollection;
@@ -9,6 +10,7 @@ interface MapLayersProps {
   flightsGeoJson: GeoJSON.FeatureCollection;
   traveledPathGeoJson?: GeoJSON.FeatureCollection;
   remainingPathGeoJson?: GeoJSON.FeatureCollection;
+  activeBBoxGeoJson?: GeoJSON.FeatureCollection;
 }
 
 /**
@@ -21,9 +23,35 @@ export function MapLayers({
   flightsGeoJson,
   traveledPathGeoJson = EMPTY_GEOJSON,
   remainingPathGeoJson = EMPTY_GEOJSON,
+  activeBBoxGeoJson = EMPTY_GEOJSON,
 }: MapLayersProps) {
+
+    const {navy, lime} = useThemeColors();
+
   return (
     <>
+      {/* Active Bounding Box Outline */}
+      <Source id="bbox-source" type="geojson" data={activeBBoxGeoJson}>
+        <Layer
+          id="bbox-outline"
+          type="line"
+          paint={{
+            "line-color": navy, // --navy
+            "line-width": 1,
+            "line-dasharray": [4, 4],
+            "line-opacity": 0.3,
+          }}
+        />
+        <Layer
+          id="bbox-fill"
+          type="fill"
+          paint={{
+            "fill-color": navy,
+            "fill-opacity": 0.02,
+          }}
+        />
+      </Source>
+
       {/* Flight Path - Traveled Segment */}
       <Source
         id="flight-path-traveled"
@@ -34,7 +62,7 @@ export function MapLayers({
           id="flight-path-traveled-line"
           type="line"
           paint={{
-            "line-color": "#1E3A8A", // --navy
+            "line-color": navy, // --navy
             "line-width": 4,
             "line-opacity": 0.8,
           }}
@@ -51,7 +79,7 @@ export function MapLayers({
           id="flight-path-remaining-line"
           type="line"
           paint={{
-            "line-color": "#1E3A8A", // --navy
+            "line-color": navy, // --navy
             "line-width": 4,
             "line-dasharray": [2, 1],
             "line-opacity": 0.6,
@@ -65,7 +93,7 @@ export function MapLayers({
           id="routes-lines"
           type="line"
           paint={{
-            "line-color": "#BEF264", // --lime
+            "line-color": lime, // --lime
             "line-width": 2,
             "line-dasharray": [3, 2],
           }}

--- a/frontend/app/telemetry/_components/TelemetryMapView.tsx
+++ b/frontend/app/telemetry/_components/TelemetryMapView.tsx
@@ -290,7 +290,7 @@ export default function TelemetryMapView() {
           onMouseLeave={onMouseLeave}
           cursor={cursor}
         >
-          <NavigationControl position="bottom-right" showCompass={true}/>
+          <NavigationControl position="bottom-right" showCompass={true} />
 
           <MapLayers
             routesGeoJson={routesGeoJson}

--- a/frontend/app/telemetry/_components/TelemetryMapView.tsx
+++ b/frontend/app/telemetry/_components/TelemetryMapView.tsx
@@ -18,6 +18,7 @@ import { MapOverlay } from "@/common/components/Map/TelemetryOverlay";
 import { FlightSearch } from "@/common/components/Map/FlightSearch";
 import { MapLayers } from "./MapLayers";
 import { PanelContainer } from "./PanelContainer";
+import { AltitudeLegend } from "./AltitudeLegend";
 import {
   MAP_STYLE_URL,
   mapAirportsToGeoJson,
@@ -300,6 +301,8 @@ export default function TelemetryMapView() {
             activeBBoxGeoJson={activeBBoxGeoJson}
           />
         </MapGL>
+
+        <AltitudeLegend />
 
         <MapOverlay
           flightsCount={flights.length}

--- a/frontend/app/telemetry/_components/TelemetryMapView.tsx
+++ b/frontend/app/telemetry/_components/TelemetryMapView.tsx
@@ -26,6 +26,7 @@ import {
   applyPolishLabels,
   loadTelemetryMapImages,
   calculateQuantizedBBox,
+  bboxToGeoJson,
   EMPTY_GEOJSON,
 } from "@/app/telemetry/_utils/telemetryMapHelpers";
 import type { Airport, AirlineWithDestinations } from "@/common/api/airports";
@@ -102,6 +103,8 @@ export default function TelemetryMapView() {
 
   const [cityAirports, setCityAirports] = useState<Airport[]>([]);
   const [highlightedIcao, setHighlightedIcao] = useState<string | null>(null);
+  const [activeBBoxGeoJson, setActiveBBoxGeoJson] =
+    useState<GeoJSON.FeatureCollection>(EMPTY_GEOJSON);
   const [cursor, setCursor] = useState<string>("");
 
   const geoJsonData = useMemo(() => mapFlightsToGeoJson(flights), [flights]);
@@ -136,6 +139,7 @@ export default function TelemetryMapView() {
       const bbox = calculateQuantizedBBox(b);
       setFlightBounds(bbox);
       setAirportBounds(bbox);
+      setActiveBBoxGeoJson(bboxToGeoJson(bbox));
     }, 500);
   }, [setFlightBounds, setAirportBounds]);
 
@@ -285,7 +289,7 @@ export default function TelemetryMapView() {
           onMouseLeave={onMouseLeave}
           cursor={cursor}
         >
-          <NavigationControl position="bottom-right" showCompass={false} />
+          <NavigationControl position="bottom-right" showCompass={true}/>
 
           <MapLayers
             routesGeoJson={routesGeoJson}
@@ -293,6 +297,7 @@ export default function TelemetryMapView() {
             flightsGeoJson={geoJsonData}
             traveledPathGeoJson={traveledPathGeoJson}
             remainingPathGeoJson={remainingPathGeoJson}
+            activeBBoxGeoJson={activeBBoxGeoJson}
           />
         </MapGL>
 

--- a/frontend/app/telemetry/_utils/telemetryMapHelpers.ts
+++ b/frontend/app/telemetry/_utils/telemetryMapHelpers.ts
@@ -88,6 +88,14 @@ export async function loadTelemetryMapImages(map: MaplibreMap) {
     );
   }
 
+  if (!map.hasImage("airplane-icon-sdf")) {
+    promises.push(
+      map.loadImage("/airplane.png").then((response) => {
+        map.addImage("airplane-icon-sdf", response.data, { sdf: true });
+      }),
+    );
+  }
+
   if (!map.hasImage("airport-icon")) {
     promises.push(tintMapImage(map, "airport-icon", "/airport.png", "#1E3A8A"));
   }

--- a/frontend/app/telemetry/_utils/telemetryMapHelpers.ts
+++ b/frontend/app/telemetry/_utils/telemetryMapHelpers.ts
@@ -102,18 +102,125 @@ export async function loadTelemetryMapImages(map: MaplibreMap) {
 }
 
 /**
- * Kwantyzuje bounding box do siatki o określonym rozmiarze,
- * aby zoptymalizować cache'owanie zapytań na backendzie.
+ * Obszar limitu dla zapytań mapy (w stopniach kwadratowych).
+ * Musi być spójny z limitem na backendzie.
  */
-export function calculateQuantizedBBox(bounds: LngLatBounds, gridSize = 2.0) {
+export const MAX_BBOX_AREA = 400;
+
+/**
+ * Kwantyzuje bounding box do siatki o określonym rozmiarze oraz ogranicza go
+ * do maksymalnej dozwolonej powierzchni, aby uniknąć błędów backendu.
+ * Zapewnia, że środek mapy pozostaje punktem centralnym pobieranych danych.
+ */
+export function calculateQuantizedBBox(
+  bounds: LngLatBounds,
+  gridSize = 2.0,
+  maxArea = MAX_BBOX_AREA,
+) {
+  const west = bounds.getWest();
+  const east = bounds.getEast();
+  const south = bounds.getSouth();
+  const north = bounds.getNorth();
+
+  const lonRange = east - west;
+  const latRange = north - south;
+  const currentArea = lonRange * latRange;
+
+  let targetLomin = west;
+  let targetLomax = east;
+  let targetLamin = south;
+  let targetLamax = north;
+
+  // 1. Jeśli obszar przekracza limit, obliczamy mniejszy prostokąt wokół środka
+  if (currentArea > maxArea) {
+    const scaleFactor = Math.sqrt(maxArea / currentArea);
+    const newLonRange = lonRange * scaleFactor;
+    const newLatRange = latRange * scaleFactor;
+    const center = bounds.getCenter();
+
+    targetLomin = center.lng - newLonRange / 2;
+    targetLomax = center.lng + newLonRange / 2;
+    targetLamin = center.lat - newLatRange / 2;
+    targetLamax = center.lat + newLatRange / 2;
+
+    // Korekta szerokości geograficznej, aby nie wykraczała poza [-90, 90]
+    if (targetLamin < -90) {
+      targetLamax += -90 - targetLamin;
+      targetLamin = -90;
+    }
+    if (targetLamax > 90) {
+      targetLamin -= targetLamax - 90;
+      targetLamax = 90;
+    }
+  }
+
+  // 2. Kwantyzacja do siatki (dla optymalizacji cache na backendzie)
   const quantizeMin = (val: number) => Math.floor(val / gridSize) * gridSize;
   const quantizeMax = (val: number) => Math.ceil(val / gridSize) * gridSize;
 
+  let qLomin = quantizeMin(targetLomin);
+  let qLamin = quantizeMin(targetLamin);
+  let qLomax = quantizeMax(targetLomax);
+  let qLamax = quantizeMax(targetLamax);
+
+  // 3. Po kwantyzacji obszar mógł ponownie przekroczyć limit (np. z 400 do 484)
+  // W takim przypadku redukujemy go, usuwając zewnętrzne pasy siatki
+  while ((qLamax - qLamin) * (qLomax - qLomin) > maxArea) {
+    const qLatRange = qLamax - qLamin;
+    const qLonRange = qLomax - qLomin;
+
+    if (qLatRange > qLonRange) {
+      qLamin += gridSize;
+      if ((qLamax - qLamin) * (qLomax - qLomin) <= maxArea) break;
+      qLamax -= gridSize;
+    } else {
+      qLomin += gridSize;
+      if ((qLamax - qLamin) * (qLomax - qLomin) <= maxArea) break;
+      qLomax -= gridSize;
+    }
+
+    if (qLamin >= qLamax || qLomin >= qLomax) break;
+  }
+
+  // 4. Finalna weryfikacja granic fizycznych
   return {
-    lomin: quantizeMin(bounds.getWest()),
-    lamin: quantizeMin(bounds.getSouth()),
-    lomax: quantizeMax(bounds.getEast()),
-    lamax: quantizeMax(bounds.getNorth()),
+    lomin: qLomin,
+    lamin: Math.max(qLamin, -90),
+    lomax: qLomax,
+    lamax: Math.min(qLamax, 90),
+  };
+}
+
+/**
+ * Konwertuje obiekt bounding box na GeoJSON Polygon,
+ * aby umożliwić jego wizualizację na mapie.
+ */
+export function bboxToGeoJson(bbox: {
+  lomin: number;
+  lamin: number;
+  lomax: number;
+  lamax: number;
+}): GeoJSON.FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [bbox.lomin, bbox.lamin],
+              [bbox.lomax, bbox.lamin],
+              [bbox.lomax, bbox.lamax],
+              [bbox.lomin, bbox.lamax],
+              [bbox.lomin, bbox.lamin],
+            ],
+          ],
+        },
+        properties: {},
+      },
+    ],
   };
 }
 

--- a/frontend/common/components/Map/FlightPanel.tsx
+++ b/frontend/common/components/Map/FlightPanel.tsx
@@ -10,6 +10,7 @@ import {
   calculateMinutesBetween,
   calculateTimeRemaining,
 } from "@/common/utils/flightUtils";
+import { getDirectionShort } from "@/common/utils/geoUtils";
 
 interface FlightPanelProps {
   properties: {
@@ -212,7 +213,7 @@ export function FlightPanel({ properties, onClose }: FlightPanelProps) {
             </span>
             <span className="font-mono font-medium text-base">
               {properties.heading != null
-                ? `${Math.round(properties.heading)}°`
+                ? `${Math.round(properties.heading)}° | ${getDirectionShort(properties.heading)}`
                 : "Brak"}
             </span>
 

--- a/frontend/common/hooks/UseThemeColors.ts
+++ b/frontend/common/hooks/UseThemeColors.ts
@@ -1,0 +1,33 @@
+import {useState, useEffect} from "react";
+
+/**
+ * Służy do ekstrakcji wartości zmiennych CSS zdefiniowanych w :root (globals.css)
+ * i udostępnia ich do formie obiektow JS
+ *
+ * @description
+ * MapLibre/Mapbox nie mają możliwości bezpośrednio odczytać stylów CSS typu `var(--color)`
+ * Ten hook to bridge, który pobiera aktualne wartości i przekazuje je do warstw map
+ *
+ */
+export function useThemeColors() {
+    const [colors, setColors] = useState({
+        navy: "#1E3A8A",
+        lime: "#BEF264",
+    });
+
+    useEffect(() => {
+        const root = document.documentElement;
+
+        const getVar = (name: string, fallback: string) => {
+            const value = getComputedStyle(root).getPropertyValue(name).trim();
+            return value || fallback
+        };
+
+        setColors({
+            navy: getVar("--navy", "#1E3A8A"),
+            lime: getVar("--lime", "#BEF264"),
+        })
+    }, []);
+
+    return colors;
+}

--- a/frontend/common/hooks/UseThemeColors.ts
+++ b/frontend/common/hooks/UseThemeColors.ts
@@ -1,4 +1,4 @@
-import {useState, useEffect} from "react";
+import { useState, useEffect } from "react";
 
 /**
  * Służy do ekstrakcji wartości zmiennych CSS zdefiniowanych w :root (globals.css)
@@ -10,28 +10,28 @@ import {useState, useEffect} from "react";
  *
  */
 export function useThemeColors() {
-    const [colors, setColors] = useState({
-        navy: "#1E3A8A",
-        lime: "#BEF264",
-        navyHover: "#0F1E4A",
-        ink: "#0A0A0A",
+  const [colors, setColors] = useState({
+    navy: "#1E3A8A",
+    lime: "#BEF264",
+    navyHover: "#0F1E4A",
+    ink: "#0A0A0A",
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    const getVar = (name: string, fallback: string) => {
+      const value = getComputedStyle(root).getPropertyValue(name).trim();
+      return value || fallback;
+    };
+
+    setColors({
+      navy: getVar("--navy", "#1E3A8A"),
+      lime: getVar("--lime", "#BEF264"),
+      navyHover: getVar("--navy-hover", "#0F1E4A"),
+      ink: getVar("--ink", "#0A0A0A"),
     });
+  }, []);
 
-    useEffect(() => {
-        const root = document.documentElement;
-
-        const getVar = (name: string, fallback: string) => {
-            const value = getComputedStyle(root).getPropertyValue(name).trim();
-            return value || fallback
-        };
-
-        setColors({
-            navy: getVar("--navy", "#1E3A8A"),
-            lime: getVar("--lime", "#BEF264"),
-            navyHover: getVar("--navy-hover", "#0F1E4A"),
-            ink: getVar("--ink", "#0A0A0A"),
-        })
-    }, []);
-
-    return colors;
+  return colors;
 }

--- a/frontend/common/hooks/UseThemeColors.ts
+++ b/frontend/common/hooks/UseThemeColors.ts
@@ -13,6 +13,8 @@ export function useThemeColors() {
     const [colors, setColors] = useState({
         navy: "#1E3A8A",
         lime: "#BEF264",
+        navyHover: "#0F1E4A",
+        ink: "#0A0A0A",
     });
 
     useEffect(() => {
@@ -26,6 +28,8 @@ export function useThemeColors() {
         setColors({
             navy: getVar("--navy", "#1E3A8A"),
             lime: getVar("--lime", "#BEF264"),
+            navyHover: getVar("--navy-hover", "#0F1E4A"),
+            ink: getVar("--ink", "#0A0A0A"),
         })
     }, []);
 

--- a/frontend/common/utils/geoUtils.ts
+++ b/frontend/common/utils/geoUtils.ts
@@ -88,3 +88,13 @@ export function getBearingAlongPath(coords: number[][], t: number): number {
     Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLon);
   return (Math.atan2(y, x) * (180 / Math.PI) + 360) % 360;
 }
+
+/**
+ * Translates heading in degrees to a universal short geographical direction (N, NE, E, etc.).
+ * @param heading Heading in degrees (0-360)
+ */
+export function getDirectionShort(heading: number): string {
+  const directions = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+  const index = Math.round(heading / 45) % 8;
+  return directions[index];
+}


### PR DESCRIPTION
This PR contributes to #86 #87 #101 

**Changes**:

Frontend: 

- Airplane color maps to the implemented linear gradient where the altitude transitions from --lime (ground level) to --navy (+12,000 meters)
- Airplane icon size now scales logarithmically with altitude
- Planes with negative altitudes are interpeted as ground level (lime color)
- Add linear gradient legend
- Add visual representation of the active bounding box
- Client will now ask the backend the maximum 400 sq deg. bounding box when user zooms out over the 400 sq deg. limit
- Add universal geographical directions (N, NE, etc.) to the displayed telemetry details.

Backend:
- Add unit tests for telemetry module
- Update and add missing JSDocs in telemetry module