### PR TITLE
Feat/centralized logging - centralized azure observability

### DIFF
--- a/.github/workflows/infrastructure-provisioning.yml
+++ b/.github/workflows/infrastructure-provisioning.yml
@@ -59,6 +59,14 @@ on:
         required: false
         type: string
         default: "dev-inz-pzal-postgis"
+      persistent_workspace_name:
+        required: false
+        type: string
+        default: "dev-inz-persistent-logs"
+      persistent_workspace_rg:
+        required: false
+        type: string
+        default: "dev-data-rg"
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -138,7 +146,9 @@ jobs:
             -var="data_subnet_name=${{ inputs.data_subnet_name }}" \
             -var="app_service_subnet_name=${{ inputs.app_service_subnet_name }}" \
             -var="nat_gateway_name=${{ inputs.nat_gateway_name }}" \
-            -var="public_ip_domain_name_label=${{ inputs.public_ip_domain_name_label }}"
+            -var="public_ip_domain_name_label=${{ inputs.public_ip_domain_name_label }}" \
+            -var="persistent_workspace_name=${{ inputs.persistent_workspace_name }}" \
+            -var="persistent_workspace_rg=${{ inputs.persistent_workspace_rg }}"
 
       - name: Get Terraform Outputs
         if: ${{ inputs.terraform_action == 'apply' }}

--- a/backend/src/common/utils/logger.ts
+++ b/backend/src/common/utils/logger.ts
@@ -65,7 +65,7 @@ class Logger {
     this.writeToFile(formatted);
   }
 
-  public warn(message: string, detail?: unknown) : void {
+  public warn(message: string, detail?: unknown): void {
     const formatted = this.formatMessage(LogLevel.WARN, message, detail);
     console.warn(formatted);
     this.writeToFile(formatted);

--- a/backend/src/common/utils/logger.ts
+++ b/backend/src/common/utils/logger.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import fs from "fs";
 import path from "path";
 
@@ -18,7 +19,7 @@ class Logger {
     this.ensureLogDir();
   }
 
-  private ensureLogDir() {
+  private ensureLogDir(): void {
     if (!fs.existsSync(this.logDir)) {
       fs.mkdirSync(this.logDir, { recursive: true });
     }
@@ -41,7 +42,10 @@ class Logger {
     return `[${timestamp}] [${level}] ${message}${detailStr}`;
   }
 
-  private writeToFile(message: string) {
+  private writeToFile(message: string): void {
+    if (process.env.NODE_ENV === "production") {
+      return;
+    }
     try {
       fs.appendFileSync(this.logFile, message + "\n");
     } catch (err) {
@@ -49,31 +53,31 @@ class Logger {
     }
   }
 
-  public writeRawLog(message: string) {
+  public writeRawLog(message: string): void {
     this.writeToFile(message);
   }
 
-  public info(message: string, detail?: unknown, logToConsole = false) {
+  public info(message: string, detail?: unknown, logToConsole = false): void {
     const formatted = this.formatMessage(LogLevel.INFO, message, detail);
-    if (logToConsole) {
+    if (logToConsole || process.env.NODE_ENV === "production") {
       console.log(formatted);
     }
     this.writeToFile(formatted);
   }
 
-  public warn(message: string, detail?: unknown) {
+  public warn(message: string, detail?: unknown) : void {
     const formatted = this.formatMessage(LogLevel.WARN, message, detail);
     console.warn(formatted);
     this.writeToFile(formatted);
   }
 
-  public error(message: string, detail?: unknown) {
+  public error(message: string, detail?: unknown): void {
     const formatted = this.formatMessage(LogLevel.ERROR, message, detail);
     console.error(formatted);
     this.writeToFile(formatted);
   }
 
-  public fatal(message: string, detail?: unknown) {
+  public fatal(message: string, detail?: unknown): void {
     const formatted = this.formatMessage(LogLevel.FATAL, message, detail);
     console.error(formatted);
     this.writeToFile(formatted);

--- a/infrastructure/terraform/azure/compute.tf
+++ b/infrastructure/terraform/azure/compute.tf
@@ -90,6 +90,7 @@ resource "azurerm_linux_web_app" "backend" {
   name                = var.backend_app_name
   resource_group_name = azurerm_resource_group.rg.name
   service_plan_id     = azurerm_service_plan.app_plan.id
+  https_only          = true
 
   virtual_network_subnet_id = azurerm_subnet.app_service_subnet.id
 
@@ -141,6 +142,7 @@ resource "azurerm_linux_web_app" "frontend" {
   location            = azurerm_resource_group.rg.location
   name                = var.frontend_app_name
   resource_group_name = azurerm_resource_group.rg.name
+  https_only          = true
 
   service_plan_id = azurerm_service_plan.app_plan.id
 

--- a/infrastructure/terraform/azure/compute.tf
+++ b/infrastructure/terraform/azure/compute.tf
@@ -221,3 +221,23 @@ resource "azurerm_monitor_autoscale_setting" "backend_autoscale" {
     }
   }
 }
+
+resource "azurerm_monitor_diagnostic_setting" "backend_diag" {
+  name                       = "backend-diagnostics"
+  target_resource_id         = azurerm_linux_web_app.backend.id
+  log_analytics_workspace_id = data.azurerm_log_analytics_workspace.persistent_logs.id
+
+  enabled_log {
+    category = "AppServiceConsoleLogs"
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "frontend_diag" {
+  name                       = "frontend-diagnostics"
+  target_resource_id         = azurerm_linux_web_app.frontend.id
+  log_analytics_workspace_id = data.azurerm_log_analytics_workspace.persistent_logs.id
+
+  enabled_log {
+    category = "AppServiceConsoleLogs"
+  }
+}

--- a/infrastructure/terraform/azure/data.tf
+++ b/infrastructure/terraform/azure/data.tf
@@ -9,3 +9,8 @@ data "azurerm_public_ip" "nat_pip" {
   name                = var.data_nat_pip
   resource_group_name = var.data_resource_group
 }
+
+data "azurerm_log_analytics_workspace" "persistent_logs" {
+  name                = var.persistent_workspace_name
+  resource_group_name = var.persistent_workspace_rg
+}

--- a/infrastructure/terraform/azure/scripts/postgis-provisioning-ubuntu.sh
+++ b/infrastructure/terraform/azure/scripts/postgis-provisioning-ubuntu.sh
@@ -184,6 +184,7 @@ update_param "jit" "off"
 # 7. SERVICE RESTART AND DATABASE INITIALIZATION
 echo "Starting PostgreSQL"
 systemctl start postgresql
+systemctl restart postgresql
 
 if [ "$IS_NEW_DATABASE" = true ]; then
     echo "Initializing new database schema and user credentials..."

--- a/infrastructure/terraform/azure/variables.tf
+++ b/infrastructure/terraform/azure/variables.tf
@@ -154,3 +154,15 @@ variable "use_existing_data" {
   default     = true
 }
 
+variable "persistent_workspace_name" {
+  type        = string
+  description = "Name of the persistent log analytics workspace"
+  default     = "pzal-log-analytics"
+}
+
+variable "persistent_workspace_rg" {
+  type        = string
+  description = "Resource group for the persistent log analytics workspace"
+  default     = "dev-data-rg"
+}
+


### PR DESCRIPTION
Issue #128 
This PR adds centralized infrastructure observability using Azure Log Analytics.

Changes
- If the backend application is run with NODE_ENV=production, all logs are streamed to stdout/stderr. Otherwise, logs will be stored in backend/app/logs/app.log
- Both frontend and backend Azure App Services stream their AppServiceConsoleLogs directly to Azure Log Analytics Workspace. 
- Injected https_only = true into both backend and frontend Azure App Service resources.. This disables port 80 HTTP traffic and enforces redirects to port 443. 